### PR TITLE
feat: lamda の url を output で表示するようにすることで動作確認をしやすくする

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -68,10 +68,6 @@ resource "aws_s3_object" "lambda_file" {
   source = "${path.module}/.temp_files/lambda.zip"
 }
 
-moved {
-  from = aws_lambda_function.first_function
-  to   = aws_lambda_function.kdg_lamda_sample
-}
 # Lambda関数を生成
 resource "aws_lambda_function" "kdg_lamda_sample" {
   function_name = "kdg-lamda-sample"
@@ -84,10 +80,6 @@ resource "aws_lambda_function" "kdg_lamda_sample" {
   s3_key        = aws_s3_object.lambda_file.key
 }
 
-moved {
-  from = aws_lambda_function_url.first_function
-  to   = aws_lambda_function_url.kdg_lamda_sample
-}
 # 外部からリクエストを飛ばすためのエンドポイント
 resource "aws_lambda_function_url" "kdg_lamda_sample" {
   function_name      = aws_lambda_function.kdg_lamda_sample.function_name

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,13 +1,13 @@
-# # CI/CD側でlambdaのソースコードを格納するための箱
-# resource "aws_s3_bucket" "lambda_artifacts" {
-#   # AWS S3 で一意である(重複がない)必要がある
-#   # 例) kdg-aws-2025-ここに自分のgithubのユーザー名-lambda-artifacts
-#   bucket = "kdg-aws-2025-honahuku-lambda-artifacts"
-#   tags = {
-#     # bucket に指定した内容と同じものを書く
-#     Name = "kdg-aws-2025-honahuku-lambda-artifacts"
-#   }
-# }
+# CI/CD側でlambdaのソースコードを格納するための箱
+resource "aws_s3_bucket" "lambda_artifacts" {
+  # AWS S3 で一意である(重複がない)必要がある
+  # 例) kdg-aws-2025-ここに自分のgithubのユーザー名-lambda-artifacts
+  bucket = "kdg-aws-2025-honahuku-lambda-artifacts"
+  tags = {
+    # bucket に指定した内容と同じものを書く
+    Name = "kdg-aws-2025-honahuku-lambda-artifacts"
+  }
+}
 
 # lambda 実行時に必要な権限をまとめる role を定義する
 resource "aws_iam_role" "lambda" {
@@ -61,27 +61,36 @@ data "archive_file" "initial_lambda_package" {
   }
 }
 
-# # (初回のみ)空のLambdaのファイルをS3にアップロード
-# resource "aws_s3_object" "lambda_file" {
-#   bucket = aws_s3_bucket.lambda_artifacts.id
-#   key    = "initial.zip"
-#   source = "${path.module}/.temp_files/lambda.zip"
-# }
+# (初回のみ)空のLambdaのファイルをS3にアップロード
+resource "aws_s3_object" "lambda_file" {
+  bucket = aws_s3_bucket.lambda_artifacts.id
+  key    = "initial.zip"
+  source = "${path.module}/.temp_files/lambda.zip"
+}
 
-# # Lambda関数を生成
-# resource "aws_lambda_function" "first_function" {
-#   function_name = "first-function"
-#   role          = aws_iam_role.lambda.arn
-#   handler       = "main.handler"
-#   runtime       = "provided.al2023"
-#   timeout       = 120
-#   publish       = true
-#   s3_bucket     = aws_s3_bucket.lambda_artifacts.id
-#   s3_key        = aws_s3_object.lambda_file.key
-# }
+moved {
+  from = aws_lambda_function.first_function
+  to   = aws_lambda_function.kdg_lamda_sample
+}
+# Lambda関数を生成
+resource "aws_lambda_function" "kdg_lamda_sample" {
+  function_name = "kdg-lamda-sample"
+  role          = aws_iam_role.lambda.arn
+  handler       = "main.handler"
+  runtime       = "provided.al2023"
+  timeout       = 120
+  publish       = true
+  s3_bucket     = aws_s3_bucket.lambda_artifacts.id
+  s3_key        = aws_s3_object.lambda_file.key
+}
 
-# # 外部からリクエストを飛ばすためのエンドポイント
-# resource "aws_lambda_function_url" "first_function" {
-#   function_name      = aws_lambda_function.first_function.function_name
-#   authorization_type = "NONE"
-# }
+moved {
+  from = aws_lambda_function_url.first_function
+  to   = aws_lambda_function_url.kdg_lamda_sample
+}
+# 外部からリクエストを飛ばすためのエンドポイント
+resource "aws_lambda_function_url" "kdg_lamda_sample" {
+  function_name      = aws_lambda_function.kdg_lamda_sample.function_name
+  authorization_type = "NONE"
+}
+

--- a/lambda.tf
+++ b/lambda.tf
@@ -94,3 +94,8 @@ resource "aws_lambda_function_url" "kdg_lamda_sample" {
   authorization_type = "NONE"
 }
 
+# Lambda関数のURLをアウトプットする
+output "lambda_kdg_lamda_sample_url" {
+  description = "デプロイした first_function の URL"
+  value       = aws_lambda_function_url.kdg_lamda_sample.function_url
+}

--- a/lambda_deploy.sh
+++ b/lambda_deploy.sh
@@ -3,7 +3,7 @@ set -exo pipefail
 
 # mktemp で作業用のディレクトリを作成 (カレントディレクトリが汚れないようにするため, 不要なファイルが zip に入らないようにするため)
 TEMPDIR=$(mktemp -d)
-# 各自のバケット名に書き換え
+# TODO: 各自のバケット名に書き換え
 ARTIFACT_BUCKET="kdg-aws-2025-honahuku-lambda-artifacts"
 cd function
 go mod download


### PR DESCRIPTION
## なぜやるか
- lamda の url を output で表示するようにすることで動作確認をしやすくしたいため

## なにをやったのか
- lamda の名前を `kdg-lamda-sample` にリネーム
- lamda の url を output として定義

## 動作確認の手順
fmt, plan, apply
